### PR TITLE
fix: use `Node` type from project instead of DOM lib

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -1,3 +1,5 @@
+import Node from "./models/Node";
+
 type Props = {
   tree: Node | null;
 };


### PR DESCRIPTION
`Tree.tsx` currently defines the `tree` prop as being of type `Node`. This pulls the `Node` type from `lib.dom.ts`. Instead, we want the `Node` type defined in the project: a tree node.